### PR TITLE
Fix for passthrough RS485 USB adapter

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -11,6 +11,7 @@ WORKDIR /usr/app
 USER node
 RUN cd src && npm install -only=production
 USER root
+usermod -a -G dialout node
 RUN apt-get remove --purge -y \
 bzr \
 git \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:latest
+FROM node:12
 
 # Copy source to container
 RUN mkdir -p /usr/app/src

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -11,7 +11,6 @@ WORKDIR /usr/app
 USER node
 RUN cd src && npm install -only=production
 USER root
-RUN usermod -a -G dialout node
 RUN apt-get remove --purge -y \
 bzr \
 git \
@@ -59,5 +58,8 @@ zlib1g-dev && \
 rm -rf /var/lib/apt/lists/*
 USER node
 COPY nibepi /usr/app/src
+USER root
+RUN usermod -a -G dialout node
+USER node
 
 CMD [ "node", "./src/server.js" ]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -11,7 +11,7 @@ WORKDIR /usr/app
 USER node
 RUN cd src && npm install -only=production
 USER root
-usermod -a -G dialout node
+RUN usermod -a -G dialout node
 RUN apt-get remove --purge -y \
 bzr \
 git \


### PR DESCRIPTION
Implemented a fix (node user needs to have group dial out) for RS485 USB adapter.

In addition it will not build on node:latest, I have therefore changed it to node:12 where it is able to complete build.