### PR TITLE
class should be 'current' instead of 'power' when publishing to MQTT

### DIFF
--- a/docker/nibepi/index.js
+++ b/docker/nibepi/index.js
@@ -1248,7 +1248,7 @@ function formatMQTTdiscovery(data) {
         if(result.unit=="°C") {
             result.type = "temperature";
         } else if(result.unit=="A") {
-            result.type = "power";
+            result.type = "current";
         } else if(result.unit=="kW") {
             result.type = "power";
         } else if(result.unit=="Hz" || result.unit=="%") {

--- a/index.js
+++ b/index.js
@@ -1258,7 +1258,7 @@ function formatMQTTdiscovery(data) {
         if(result.unit=="°C") {
             result.type = "temperature";
         } else if(result.unit=="A") {
-            result.type = "power";
+            result.type = "current";
         } else if(result.unit=="kW") {
             result.type = "power";
         } else if(result.unit=="Hz" || result.unit=="%") {


### PR DESCRIPTION
See https://developers.home-assistant.io/docs/core/entity/sensor/
Device class power requires W or kW as unit_of_measurement.
Device class current requires A or mA as unit_of_measurement.

![image](https://github.com/anerdins/nibepi/assets/3329311/817bb86b-bab3-4f72-af2c-13042ad669ac)
